### PR TITLE
add parameter of batch size for ConvNet inference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 script:
 - chunkflow generate-task --shape 28 320 320 --offset 4 64 64 upload-log --log-path file:///tmp/test/log
 - chunkflow create-chunk write-h5 --file-name=/tmp/img.h5 read-file --file-name=/tmp/img.h5
-- chunkflow create-chunk --size 36 448 448 inference  cloud-watch
+- chunkflow create-chunk --size 36 448 448 inference  --batch-size 3 cloud-watch
 # use -a to append to the coverage file, otherwise it will clean previous record
 - cd chunkflow
 - coverage run --source=chunkflow -m unittest

--- a/chunkflow/flow.py
+++ b/chunkflow/flow.py
@@ -251,10 +251,11 @@ def normalize_contrast_contrast_cmd(tasks, name, levels_path, mip, clip_fraction
 @click.option('--num-output-channels', type=int, default=3, help='number of output channels')
 @click.option('--framework', type=click.Choice(['identity', 'pznet', 'pytorch', 'pytorch-multitask']), 
               default='pytorch-multitask', help='inference framework')
+@click.option('--batch-size', type=int, default=1, help='mini batch size of input patch.')
 @operator
 def inference_cmd(tasks, name, convnet_model, convnet_weight_path, patch_size,
               patch_overlap, output_key, original_num_output_channels,
-              num_output_channels, framework):
+              num_output_channels, framework, batch_size):
     """[operator] Perform convolutional network inference for chunks."""
     state['operators'][name] = InferenceOperator(
         convnet_model, convnet_weight_path, 
@@ -263,6 +264,7 @@ def inference_cmd(tasks, name, convnet_model, convnet_weight_path, patch_size,
         original_num_output_channels=original_num_output_channels,
         patch_overlap=patch_overlap,
         framework='identity',
+        batch_size=batch_size,
         verbose=state['verbose'], name=name)
 
     for task in tasks:

--- a/chunkflow/operators/block_inference/frameworks/identity_patch_inference_engine.py
+++ b/chunkflow/operators/block_inference/frameworks/identity_patch_inference_engine.py
@@ -16,12 +16,14 @@ class IdentityPatchInferenceEngine(PatchInferenceEngine):
 
     def __call__(self, patch):
         """
-        return the same with argument 
+        return the same with argument
         reshape the size to 5 dimension:
-        batch, channel, z, y, x 
+        batch, channel, z, y, x
         """
-        output = np.reshape(np.copy(patch), (1, 1, *patch.shape))
+        patch = self._reshape_patch(patch)
+
+        output = np.copy(patch)
         if self.num_output_channels > 1:
-            output = np.repeat(output, 3, axis=1)
-        
+            output = np.repeat(output, self.num_output_channels, axis=1)
+
         return output

--- a/chunkflow/operators/block_inference/frameworks/patch_inference_engine.py
+++ b/chunkflow/operators/block_inference/frameworks/patch_inference_engine.py
@@ -1,6 +1,21 @@
+import numpy as np
+
 class PatchInferenceEngine(object):
     def __init__(self):
         pass
 
     def __call__(self, patch):
+        """
+        this method should be inherited for real implementation
+        """
         return NotImplementedError()
+
+    def _reshape_patch(self, patch):
+        """patch should be a 5d np array
+        """
+        assert isinstance(patch, np.ndarray)
+        if patch.ndim == 3:
+            patch = patch.reshape((1, 1) + patch.shape)
+        elif patch.ndim == 4:
+            patch = patch.reshape((1, ) + patch.shape)
+        return patch

--- a/chunkflow/operators/block_inference/frameworks/pytorch_multitask_patch_inference.py
+++ b/chunkflow/operators/block_inference/frameworks/pytorch_multitask_patch_inference.py
@@ -46,12 +46,8 @@ class PytorchMultitaskPatchInferenceEngine(PatchInferenceEngine):
         assert len(self.opt.in_spec) == 1
 
     def __call__(self, patch):
-        # patch should be a 5d np array
-        #assert isinstance(patch, np.ndarray)
-        if patch.ndim == 3:
-            patch = patch.reshape((1, 1) + patch.shape)
-        elif patch.ndim == 4:
-            patch = patch.reshape((1, ) + patch.shape)
+        # make sure that patch is 5d ndarray
+        patch = self._reshape_patch(patch)
 
         with torch.no_grad():
             inputs = dict()
@@ -60,5 +56,4 @@ class PytorchMultitaskPatchInferenceEngine(PatchInferenceEngine):
                 inputs[k] = torch.from_numpy(patch).cuda()
             outputs = self.net(inputs)
             output = outputs[self.output_key].cpu().numpy()
-            #output = np.squeeze(output)
             return output

--- a/chunkflow/operators/block_inference/frameworks/pytorch_patch_inference_engine.py
+++ b/chunkflow/operators/block_inference/frameworks/pytorch_patch_inference_engine.py
@@ -37,12 +37,8 @@ class PytorchPatchInferenceEngine(PatchInferenceEngine):
             self.net.eval()
 
     def __call__(self, patch):
-        # patch should be a 5d np array
-        #assert isinstance(patch, np.ndarray)
-        if patch.ndim == 3:
-            patch = patch.reshape((1, 1) + patch.shape)
-        elif patch.ndim == 4:
-            patch = patch.reshape((1, ) + patch.shape)
+        # make sure that the patch is 5d ndarray
+        patch = self._reshape_patch(patch)
 
         with torch.no_grad():
             in_v = torch.from_numpy(patch).cuda()

--- a/chunkflow/operators/block_inference/frameworks/pznet_patch_inference_engine.py
+++ b/chunkflow/operators/block_inference/frameworks/pznet_patch_inference_engine.py
@@ -12,14 +12,16 @@ class PZNetPatchInferenceEngine(PatchInferenceEngine):
         self.net = pznet.znet()
         self.net.load_net(net_dir)
 
-    def __call__(self, input_patch):
+    def __call__(self, patch):
         """
         args:
-            input_patch (5d numpy array): input patch with dimensions \
+            patch (5d numpy array): input patch with dimensions \
                 batch/channel/z/y/x
         return:
             5d numpy array with the same dimension arrangment.
         """
+        # make sure that the input patch is 5d ndarray
+        patch = self._reshape_patch(patch)
         return self.net.forward(input_patch)
 
 

--- a/chunkflow/operators/block_inference/test_block_inference_engine.py
+++ b/chunkflow/operators/block_inference/test_block_inference_engine.py
@@ -15,6 +15,7 @@ class TestBlockInferenceEngine(unittest.TestCase):
             patch_size=(32, 256, 256),
             patch_overlap=patch_overlap,
             num_output_channels=1,
+            batch_size=2
         )
         
         image = np.random.randint(0, 255, size=(28 * 2 + 4, 

--- a/chunkflow/operators/inference.py
+++ b/chunkflow/operators/inference.py
@@ -8,6 +8,7 @@ class InferenceOperator(OperatorBase):
                  original_num_output_channels: int=3,
                  patch_overlap=(4, 64, 64),
                  framework: str='identity',
+                 batch_size=1,
                  verbose: bool=True, name: str='inference'):
 
         super().__init__(name=name)
@@ -60,6 +61,7 @@ class InferenceOperator(OperatorBase):
             output_key=output_key,
             num_output_channels=num_output_channels,
             is_masked_in_device=is_masked_in_device,
+            batch_size=batch_size,
             verbose=verbose)
  
     def __call__(self, chunk):

--- a/chunkflow/test/test_pipeline.py
+++ b/chunkflow/test/test_pipeline.py
@@ -105,7 +105,7 @@ class TestInferencePipeline(unittest.TestCase):
         inference_operator = InferenceOperator(
             None, None, patch_size=self.patch_size, output_key='affinity',
             num_output_channels=3, patch_overlap=self.patch_overlap,
-            framework='identity')
+            framework='identity', batch_size=3)
         chunk = inference_operator(chunk)
         print('after inference: {}'.format(chunk.slices))
         


### PR DESCRIPTION
previously, the batch size is always 1.
we can use batch size more than 1 to increase efficiency.