### PR TITLE
fix docs build in readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,3 +22,4 @@ python:
   install:
     - requirements: requirements.txt
     - requirements: docs/requirements.txt
+  system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,5 @@ sphinx:
 python:
   version: 3.7
   install:
+    - requirements: requirements.txt
     - requirements: docs/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ install:
 
 script:
 - coverage run --source=./chunkflow chunkflow generate-task
-- coverage run --source=./chunkflow chunkflow create-chunk -o seg create-chunk -o gt evaluate-segmentation -s seg -g gt
+# remove this test because we are not requiring waterz package in default and it is not included in our requirements.txt since readthedocs docker do not have libboost-dev package.
+#- coverage run --source=./chunkflow chunkflow create-chunk -o seg create-chunk -o gt evaluate-segmentation -s seg -g gt
 - coverage run -a --source=./chunkflow chunkflow create-chunk write-h5 --file-name=/tmp/img.h5 
 - if test -f /tmp/img.h5 ; then echo "File found"; else exit 1; fi
 - coverage run -a --source=./chunkflow chunkflow read-h5 --file-name=/tmp/img.h5

--- a/chunkflow/chunk/segmentation.py
+++ b/chunkflow/chunk/segmentation.py
@@ -2,7 +2,6 @@ __doc__ = """Image chunk class"""
 
 import numpy as np
 from .base import Chunk
-from waterz import evaluate
 
 
 class Segmentation(Chunk):
@@ -22,6 +21,7 @@ class Segmentation(Chunk):
         return obj
 
     def evaluate(self, groundtruth):
+        from waterz import evaluate
         if not np.issubdtype(self.dtype, np.uint64):
             this = self.astype(np.uint64)
         else:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ release = verstr
 #release = chunkflow.__release__
 
 # -- General configuration ---------------------------------------------------
-#autodoc_mock_imports = ["numpy"]
+autodoc_mock_imports = ["waterz", "libchunkflow"]
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,18 @@ import re
 import sys
 sys.path.insert(0, path.abspath('../..'))
 
+# mock some modules
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+MOCK_MODULES = ['waterz', 'libchunkflow']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+
 # -- Project information -----------------------------------------------------
 
 project = 'chunkflow'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ tinybrain
 zmesh
 pybind11
 tifffile
-waterzed


### PR DESCRIPTION
We need to build the whole package since the api.rst need it to generate all the documents.
the dependency of libboost from waterz do not work.