### PR TITLE
modification for Cremi test

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,6 @@
+[TYPECHECK]
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=numpy.*,torch.*

--- a/chunkflow/chunk/image/convnet/patch/patch_mask.py
+++ b/chunkflow/chunk/image/convnet/patch/patch_mask.py
@@ -54,7 +54,7 @@ def make_bump_map(patch_size):
                       (1.0 - zv * zv))
 
     # make the low value a little bit higher to avoid floating point error
-    threshold = np.max(bump_map) * 1e-5
+    threshold = np.max(bump_map) * 1e-8
     bump_map[bump_map < threshold] = threshold
     return np.asarray(bump_map, dtype='float64')
 

--- a/chunkflow/chunk/image/convnet/patch/pytorch.py
+++ b/chunkflow/chunk/image/convnet/patch/pytorch.py
@@ -1,8 +1,6 @@
 # from .inference_engine import InferenceEngine
 # import imp
-from typing import Union
 import torch
-import numpy as np
 from .base import PatchInferencerBase
 from chunkflow.lib import load_source
 
@@ -41,7 +39,7 @@ class PyTorch(PatchInferencerBase):
         if torch.cuda.is_available():
             self.is_gpu = True
             # put mask to gpu
-            self.mask = torch.from_numpy(self.mask).cuda()
+            self.output_patch_mask = torch.from_numpy(self.output_patch_mask).cuda()
         else:
             self.is_gpu = False
 

--- a/chunkflow/flow/flow.py
+++ b/chunkflow/flow/flow.py
@@ -783,8 +783,7 @@ def inference(tasks, name, convnet_model, convnet_weight_path, input_patch_size,
         batch_size=batch_size,
         bump=bump,
         mask_output_chunk=mask_output_chunk,
-        verbose=state['verbose'],
-        name=name)
+        verbose=state['verbose'])
 
     for task in tasks:
         handle_task_skip(task, name)

--- a/chunkflow/flow/flow.py
+++ b/chunkflow/flow/flow.py
@@ -757,9 +757,8 @@ def copy_var(tasks, name, from_name, to_name):
 @click.option('--bump',
               type=click.Choice(['wu', 'zung']), default='wu',
               help='bump function type. only works with pytorch-multitask backend.')
-@click.option('--mask-output-chunk/--no-mask-output-chunk',
-              default=False, help='mask output chunk will make the whole '
-              + 'chunk like one output patch. '
+@click.option('--mask-output-chunk/--no-mask-output-chunk', default=False,
+              help='mask output chunk will make the whole chunk like one output patch. '
               + 'This will also work with non-aligned chunk size.')
 @click.option('--input-chunk-name', '-i',
               type=str, default='chunk', help='input chunk name')


### PR DESCRIPTION
- fixed chunk mask in the case of pytorch-multitask. We have to use chunkflow's patch mask to make it work since we thresholded the patch mask for numerical stability.