### PR TITLE
downsample in 3D and mask out chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ChangeLog history
 - support disbatch in manifest operator
 - add voxel size of chunk
 - automatically use chunk voxel size in neuroglancer operator
+- mask out a chunk with smaller voxel size. The voxel size should be divisible though.
 ## Bug Fixes 
 - fix manifest by updating cloud storage to CloudFiles
 

--- a/chunkflow/flow/downsample_upload.py
+++ b/chunkflow/flow/downsample_upload.py
@@ -63,7 +63,6 @@ class DownsampleUploadOperator(OperatorBase):
         voxel_offset = chunk.voxel_offset
 
         num_mips = self.stop_mip - self.chunk_mip
-
         # tinybrain use F order and require 4D array!
         chunk2 = np.transpose(chunk)
         # chunk2 = np.reshape(chunk2, (*chunk2.shape, 1))

--- a/chunkflow/flow/flow.py
+++ b/chunkflow/flow/flow.py
@@ -225,12 +225,16 @@ def cloud_watch(tasks, name, log_name):
 @click.option('--block-size', '-b',
               type=int, nargs=3, required=True,
               help='chunk size of each file.')
+@click.option('--factor', '-f',
+              type=int, nargs=3, default=(2,2,2),
+              help='hierarchical downsampling factor')
 @click.option('--max-mip', '-m',
               type=int, default=0, 
               help = 'maximum mip level.')
 @operator
-def create_info(tasks,input_chunk_name, output_layer_path, channel_num, layer_type, data_type, encoding, voxel_size, 
-                voxel_offset, volume_size, block_size, max_mip):
+def create_info(tasks,input_chunk_name: str, output_layer_path: str, channel_num: int, 
+                layer_type: str, data_type: str, encoding: str, voxel_size: tuple, 
+                voxel_offset: tuple, volume_size: tuple, block_size: tuple, factor: tuple, max_mip: int):
     
     for task in tasks:
         if input_chunk_name in task:
@@ -264,6 +268,7 @@ def create_info(tasks,input_chunk_name, output_layer_path, channel_num, layer_ty
             voxel_offset=voxel_offset[::-1],
             volume_size=volume_size[::-1],
             chunk_size=block_size[::-1],
+            factor=Vec(factor),
             max_mip=max_mip)
         vol = CloudVolume(output_layer_path, info=info)
         vol.commit_info()
@@ -723,12 +728,12 @@ def read_precomputed(tasks, name, volume_path, mip, chunk_start, chunk_size, exp
         else:
             # use bounding box of volume
             if chunk_start is None:
-                chunk_start = operator.vol.mip_bounds(mip).minpt
+                chunk_start = operator.vol.mip_bounds(mip).minpt[::-1]
             else:
                 chunk_start = Vec(*chunk_start)
 
             if chunk_size is None:
-                chunk_stop = operator.vol.mip_bounds(mip).maxpt
+                chunk_stop = operator.vol.mip_bounds(mip).maxpt[::-1]
                 chunk_size = chunk_stop - chunk_start
             else:
                 chunk_size = Vec(*chunk_size)

--- a/chunkflow/flow/mask.py
+++ b/chunkflow/flow/mask.py
@@ -44,11 +44,11 @@ class MaskOperator(OperatorBase):
 
     def is_all_zero(self, bbox):
         mask_in_high_mip = self._read_mask_in_high_mip(bbox)
-        # To-Do: replace with np.array_equiv function
-        # return np.array_equiv(mask_in_high_mip, 0)
         return np.alltrue(mask_in_high_mip == 0)
 
     def maskout(self, chunk):
+        """ Make part of chunk to be black according to a mask chunk.
+        """
         logging.info('mask out chunk using {} in mip {}'.format(
                 self.volume_path, self.mask_mip))
         
@@ -101,7 +101,6 @@ class MaskOperator(OperatorBase):
         # print("download mask chunk...")
         # make sure that the slices only contains zyx without channel
         chunk_slices = chunk_bbox.to_slices()[-3:]
-        chunk_size = chunk_bbox.maxpt - chunk_bbox.minpt
 
         # assume that input mip is the same with output mip
         xyfactor = 2**(self.mask_mip - self.chunk_mip)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ kimimaro
 Pillow
 urllib3==1.25.11
 chardet==3.0.4
-docutils==0.15
+docutils<0.16,>=0.10


### PR DESCRIPTION
- add factor parameter for create-info operator; 
- fix a bug to use bounding box from read-precomputed operator
- add function to mask out another chunk with smaller voxel size.