### PR TITLE
perf: faster PNG encode/decode

### DIFF
--- a/chunkflow/flow/read_pngs.py
+++ b/chunkflow/flow/read_pngs.py
@@ -7,11 +7,7 @@ from chunkflow.lib.bounding_boxes import BoundingBox, Cartesian
 from chunkflow.chunk import Chunk
 
 from tqdm import tqdm
-from PIL import Image
-# the default setting have a limit to avoid decompression bombs
-# https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=maximum_pixels#PIL.Image.open
-Image.MAX_IMAGE_PIXELS = None 
-
+import pyspng
 
 def read_png_images(path_prefix: str, bbox: BoundingBox, 
                         volume_offset: tuple = (0, 0, 0),
@@ -31,8 +27,8 @@ def read_png_images(path_prefix: str, bbox: BoundingBox,
         file_name = f'{path_prefix}{z:0>{digit_num}d}.png'
         file_name = path.expanduser(file_name)
         if path.exists(file_name):
-            img = Image.open(file_name)
-            img = np.asarray(img)
+            with open(file_name, "rb") as f:
+                img = pyspng.load(f.read())
             img = np.expand_dims(img, axis=0)
             img_chunk = Chunk(
                 img,

--- a/chunkflow/flow/write_pngs.py
+++ b/chunkflow/flow/write_pngs.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 from tqdm import tqdm
-from skimage.io import imsave
+import pyspng
 
 from chunkflow.chunk import Chunk
 
@@ -35,4 +35,6 @@ class WritePNGsOperator(OperatorBase):
         for z in tqdm(range(chunk.voxel_offset[0], chunk.bbox.maxpt[0])):
             img = chunk.cutout((slice(z,z+1), chunk.slices[1], chunk.slices[2]))
             img = img.array[0,:,:]
-            imsave(os.path.join(self.output_path, '{:05d}.png'.format(z)), img)
+            filename = os.path.join(self.output_path, f"{z:05d}.png")
+            with open(filename, "wb") as f:
+                f.write(pyspng.encode(img))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -40,7 +40,6 @@ dependencies:
   - olefile=0.46=pyh9f0ad1d_1
   - openssl=1.1.1h=h7b6447c_0
   - packaging=20.4=pyh9f0ad1d_0
-  - pillow=8.0.1=py37h63a5d19_0
   - pip=20.3.1=pyhd8ed1ab_0
   - pluggy=0.13.1=py37he5f6b98_3
   - py=1.9.0=pyh9f0ad1d_0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ zmesh
 fastremap
 matplotlib
 kimimaro
-Pillow
+pyspng-seunglab~=1.0.0
 pyparsing>=2.4.2
 urllib3>=1.25.11
 docutils>=0.10


### PR DESCRIPTION
Hi Jingpeng! I noticed your code is using Pillow for reading PNGs and it was recently updated, so I figure you might benefit from the recent speedup I got with pyspng-seunglab. I don't know how to test it, but I figured I could at least give you the skeleton code to start with.

I plan on maintaining pyspng-seunglab until the changes get merged upstream, but the maintainer has had total radio silence for weeks, so I am not optimistic about a merge at this point. In any case, it should be a drop in replacement in your dependencies if that ever happens if you ever want to switch.

Hope this is helpful and not annoying lol. <3