### PR TITLE
Have gaussian_filter plugin operate on copy of input so it does not modify it in-place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ jwu
 *.egg-info/
 .ipynb_checkpoints/
 .vscode/
+*.idea/
 docker/inference/build_docker.sh
 docker/inference/pytorch-emvision/
 docker/inference/pytorch-model/

--- a/chunkflow/plugins/gaussian_filter.py
+++ b/chunkflow/plugins/gaussian_filter.py
@@ -1,20 +1,22 @@
+import numpy as np
 from chunkflow.chunk import Chunk
 
 from scipy.ndimage import gaussian_filter
 
 
 def execute(chunk: Chunk, sigma: float=1.):
+    filtered = chunk.clone()
     for z in range(chunk.shape[-3]):
         if chunk.ndim == 4:
             for channel in range(chunk.shape[0]):
-                chunk.array[channel, z,:,:] = gaussian_filter(
+                filtered.array[channel, z,:,:] = gaussian_filter(
                     chunk.array[channel,z,:,:], sigma=sigma)
         elif chunk.ndim == 3:
-            chunk.array[z,:,:] = gaussian_filter(
+            filtered.array[z,:,:] = gaussian_filter(
                 chunk.array[z,:,:], sigma=sigma)
         else:
             raise ValueError(f'only support 4 or 3d, but got {chunk.ndim}')
 
     # 2d processing in xy plane
-    # chunk.array = gaussian_filter(chunk.array, sigma=sigma)
-    return chunk
+    # filtered.array = gaussian_filter(chunk.array, sigma=sigma)
+    return filtered

--- a/chunkflow/plugins/gaussian_filter.py
+++ b/chunkflow/plugins/gaussian_filter.py
@@ -4,19 +4,20 @@ from chunkflow.chunk import Chunk
 from scipy.ndimage import gaussian_filter
 
 
-def execute(chunk: Chunk, sigma: float=1.):
-    filtered = chunk.clone()
+def execute(chunk: Chunk, sigma: float=1., inplace=False):
+    if not inplace:
+        chunk = chunk.clone()
     for z in range(chunk.shape[-3]):
         if chunk.ndim == 4:
             for channel in range(chunk.shape[0]):
-                filtered.array[channel, z,:,:] = gaussian_filter(
+                chunk.array[channel, z,:,:] = gaussian_filter(
                     chunk.array[channel,z,:,:], sigma=sigma)
         elif chunk.ndim == 3:
-            filtered.array[z,:,:] = gaussian_filter(
+            chunk.array[z,:,:] = gaussian_filter(
                 chunk.array[z,:,:], sigma=sigma)
         else:
             raise ValueError(f'only support 4 or 3d, but got {chunk.ndim}')
 
     # 2d processing in xy plane
-    # filtered.array = gaussian_filter(chunk.array, sigma=sigma)
-    return filtered
+    # chunk.array = gaussian_filter(chunk.array, sigma=sigma)
+    return chunk


### PR DESCRIPTION
As currently implemented, the `gaussian_filter` plugin modifies its input data in-place. While more memory-efficient, this is unexpected and can cause problems downstream, so this change has it operate on a copy of the input data.