### PR TITLE
fix load_png_images to use bounding box starts & stops

### DIFF
--- a/chunkflow/flow/load_pngs.py
+++ b/chunkflow/flow/load_pngs.py
@@ -16,6 +16,7 @@ def load_image(file_name: str):
     # img = np.expand_dims(img, axis=0)
     return img
 
+
 def load_png_images(
         path_prefix: str, 
         bbox: BoundingBox = None, 
@@ -59,7 +60,7 @@ def load_png_images(
         if os.path.exists(file_name):
             img = load_image(file_name)
             img = img.astype(dtype=dtype)
-            chunk.array[z_offset, :, :] = img
+            chunk.array[z_offset, :, :] = img[bbox.start[1]:bbox.stop[1], bbox.start[2]:bbox.stop[2]]
         else:
             print(f'image file do not exist: {file_name}')
     

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ['chunkflow']


### PR DESCRIPTION
I fixed the ability to load pngs from smaller chunks. Note that this is not very speed efficient, because each chunk task will load the number of pngs specified by the chunk size in the `z` dimension (e.g., 128), but at least it will not store the full pngs in memory, only the portions specified by the `x, y` chunk dimensions.