### PR TITLE
fix: update viewer to new microviewer dependency

### DIFF
--- a/chunkflow/flow/view.py
+++ b/chunkflow/flow/view.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from cloudvolume import view, hyperview
+from microviewer import view, hyperview
 from .base import OperatorBase
 
 
@@ -20,4 +20,4 @@ class ViewOperator(OperatorBase):
             # this is an image
             view(chunk)
         else:
-            view(chunk, segmentation=True)
+            view(chunk, seg=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ gputil
 traitlets
 zarr
 scipy
+microviewer


### PR DESCRIPTION
from cloudvolume import view is deprecated in CV 9.0.0

Hi Jingpeng!

I'm planning on deprecating `from cloudvolume import view, hyperview` as all of that functionality is in the microviewer package now and has been for some time.

This PR should be a drop-in replacement with more functionality.

Hope this is helpful.